### PR TITLE
prevent new sms message from displaying for anon users.

### DIFF
--- a/CRM/Smsinbox/Utils.php
+++ b/CRM/Smsinbox/Utils.php
@@ -10,7 +10,10 @@ class CRM_Smsinbox_Utils {
    * If there are unread SMS messages, this displays a message.
    */
   public static function checkForUnreadMessageStatus() {
-
+    if (!CRM_Core_Permission::check('send SMS')) {
+      // Permission denied.
+      return;
+    }
     $unreadMessageCount = CRM_Smsinbox_SmsInbound::count_unread(); 
 
     if (0 == $unreadMessageCount) {


### PR DESCRIPTION
We may want to add more permission checks - so you can't access the SMS inbox if you don't have SMS Send priveleges. However, I'm including just this fix for now because it's the most urgent (we have contribution pages showing SMS Inbox alerts which is not great).