### PR TITLE
Prevent display of ACL protected contents

### DIFF
--- a/CRM/Smsinbox/SmsInbound.php
+++ b/CRM/Smsinbox/SmsInbound.php
@@ -29,18 +29,28 @@ class CRM_Smsinbox_SmsInbound {
       'record_type_id',                                
       'Activity Source'                                                                              
     );
-    $query = "
-      SELECT DISTINCT contact.display_name, email.email, state.read_status, activity.id, activity.details, activity.activity_date_time, activity_contact.contact_id
-      FROM civicrm_activity activity 
+    $select_clause = "SELECT DISTINCT
+      contact.display_name, email.email, state.read_status, activity.id, activity.details, activity.activity_date_time, activity_contact.contact_id";
+    $from_clause = "FROM civicrm_activity activity
         JOIN civicrm_option_value ov ON activity.activity_type_id = ov.value AND name = 'Inbound SMS'
         JOIN civicrm_option_group og ON ov.option_group_id = og.id AND og.name = 'activity_type'
         LEFT JOIN civicrm_activity_contact activity_contact ON activity.id = activity_contact.activity_id AND record_type_id = %0
         LEFT JOIN civicrm_smsinbox_state state ON activity.id = state.activity_id
         LEFT JOIN civicrm_contact contact ON activity_contact.contact_id = contact.id
-        LEFT JOIN civicrm_email email ON email.contact_id = activity_contact.contact_id AND email.is_primary = 1
-      ORDER BY activity.activity_date_time DESC
-      LIMIT %1 OFFSET %2
-      ";
+        LEFT JOIN civicrm_email email ON email.contact_id = activity_contact.contact_id AND email.is_primary = 1";
+    $order_clause = "ORDER BY activity.activity_date_time DESC";
+    $limit_clause = "LIMIT %1 OFFSET %2";
+
+    if (!CRM_Core_Permission::check('view all contacts')) {
+      $acl = CRM_Contact_BAO_Contact_Permission::cacheClause('contact');
+      $from_clause .= " " . $acl[0];
+      $where_clause = " WHERE " . $acl[1];
+    }
+    else {
+      $where_clause = NULL;
+    }
+
+    $query = "${select_clause} ${from_clause} ${where_clause} ${order_clause} ${limit_clause}";
     $params = [ 0 => [ $source_record_type_id, 'Integer' ], 1 => [ $limit, 'Integer' ], 2 => [ $offset, 'Integer' ] ];
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     while ($dao->fetch()) {


### PR DESCRIPTION
Without this patch, users that have ACL permission restrictions
see inbound SMS messages from contacts they should not have
access to.