### PR TITLE
use standard CiviCRM status framework for new SMS notification

### DIFF
--- a/CRM/Smsinbox/Utils.php
+++ b/CRM/Smsinbox/Utils.php
@@ -10,11 +10,10 @@ class CRM_Smsinbox_Utils {
    * If there are unread SMS messages, this displays a message.
    */
   public static function checkForUnreadMessageStatus() {
-
     $unreadMessageCount = CRM_Smsinbox_SmsInbound::count_unread(); 
 
     if (0 == $unreadMessageCount) {
-      return;
+      return NULL;
     }
     elseif (1 == $unreadMessageCount) {
       $message = 'You have one unread SMS message. Click <a href="/civicrm/smsinbox">here</a> to read it.';
@@ -23,9 +22,7 @@ class CRM_Smsinbox_Utils {
       $message = 'You have %1 unread SMS messages. Click <a href="/civicrm/smsinbox">here</a> to read them.';
     }
 
-    CRM_Core_Session::setStatus(E::ts($message, array(
-      1 => $unreadMessageCount,
-    )), '', 'info');
+    return E::ts($message, [1 => $unreadMessageCount]);
   }
 
   public static function getDisplayNameWithFallback($contactId) {


### PR DESCRIPTION
With this change, the new SMS messages notification stops showing up
on every page load and is incorporated into the standard CiviCRM
status page.

This reduces page clutter and user irritation.